### PR TITLE
add Time4J-dumper

### DIFF
--- a/java/org/nodatime/tzvalidate/Time4JDump.java
+++ b/java/org/nodatime/tzvalidate/Time4JDump.java
@@ -1,0 +1,83 @@
+// Copyright 2015 Jon Skeet. All rights reserved.
+// Use of this source code is governed by the Apache License 2.0,
+// as found in the LICENSE.txt file.
+
+package org.nodatime.tzvalidate;
+
+import net.time4j.Moment;
+import net.time4j.PlainTimestamp;
+import net.time4j.format.expert.ChronoFormatter;
+import net.time4j.format.expert.PatternType;
+import net.time4j.scale.TimeScale;
+import net.time4j.tz.TZID;
+import net.time4j.tz.Timezone;
+import net.time4j.tz.TransitionHistory;
+import net.time4j.tz.ZonalOffset;
+import net.time4j.tz.ZonalTransition;
+import org.apache.commons.cli.ParseException;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.Locale;
+import java.util.stream.Collectors;
+
+public final class Time4JDump implements ZoneDumper {
+    private static final ChronoFormatter<Moment> MOMENT_FORMATTER =
+        ChronoFormatter.ofMomentPattern("uuuu-MM-dd HH:mm:ssXXX", PatternType.CLDR, Locale.ROOT, ZonalOffset.UTC);
+
+    private static final ChronoFormatter<Moment> ZONE_NAME_FORMATTER =
+        ChronoFormatter.setUp(Moment.axis(), Locale.ROOT).addLiteral(' ').addShortTimezoneName().build();
+
+    // actually unused because it relies on non-historic JDK-data (originating from CLDR)
+    // and not on historic abbreviations contained in TZDB (which are partially invented however)
+    private final boolean printingNames = false;
+
+    public static void main(String[] args) throws IOException, ParseException {
+        DumpCoordinator.dump(new Time4JDump(), false, args);
+    }
+
+    public void dumpZone(String id, int fromYear, int toYear, Writer writer) throws IOException {
+        writer.write(id + "\n");
+
+        Timezone tz = Timezone.of(id);
+        TransitionHistory history = tz.getHistory();
+
+        String name = "";
+        if (this.printingNames) {
+            name = " -"; // we consider the era before first recorded transition as having no timezone concept at all
+        }
+        writer.write("Initially:          " + format(history.getInitialOffset()) + " standard" + name + "\n");
+
+        Moment start = PlainTimestamp.of(fromYear, 1, 1, 0, 0, 0).atUTC();
+        Moment end = PlainTimestamp.of(toYear, 1, 1, 0, 0, 0).atUTC();
+
+        for (ZonalTransition transition : history.getTransitions(start, end)) {
+            Moment transitionTime = Moment.of(transition.getPosixTime(), TimeScale.POSIX);
+            ZonalOffset offsetAfter = ZonalOffset.ofTotalSeconds(transition.getTotalOffset());
+            String dstInfo = transition.isDaylightSaving() ? " daylight" : " standard";
+            if (this.printingNames) {
+                name = ZONE_NAME_FORMATTER.with(tz).format(transitionTime);
+            }
+            writer.write(MOMENT_FORMATTER.format(transitionTime) + format(offsetAfter) + dstInfo + name + "\n");
+        }
+    }
+
+    @Override
+    public void initialize(DumpOptions options) {
+        // configuring member "printingNames" based on dump options ?
+    }
+
+    @Override
+    public Iterable<String> getZoneIds() {
+        return Timezone.getAvailableIDs().stream().map(TZID::canonical).collect(Collectors.toList());
+    }
+
+    private static String format(ZonalOffset offset) {
+        String s = " " + offset.toString();
+        if (offset.getAbsoluteSeconds() == 0) {
+            s += ":00";
+        }
+        return s;
+    }
+
+}


### PR DESCRIPTION
Let me first say that your project is very useful. Now the details...

**Required dependencies are (in maven format):**
- net.time4j:time4j-core:4.17
- net.time4j:time4j-olson:4.17
- net.time4j:time4j-i18n:4.17
- net.time4j:time4j-tzdata:1.10-2016f

I am not quite sure how to add these dependencies to your project, therefore here only given as informational comment. Future tz-version-updates should only require to change the tz-data-module.

**About zone name abbreviations:**

While I have prepared the option to print zone name abbreviations (actually inactive) I please you to consider following facts: The underlying mechanism uses the data of JDK. Joda-Time and the standard Java-dumpers for versions 7+8 do the same. Here, the critical point is that these data are NOT historized (for example "LMT" is missing) and originate from CLDR data only using the actual names. These data are NOT identical to those contained in IANA-TZDB.

My conclusion: We should leave out this naming option in general for ALL Java-based dumpers. However, if you still think that the JDK zone name data are useful then feel free to switch on the member `printingNames` to the value `true` in the class `Time4JDumper`.

**Other suggestions for improvements:**
- I have noticed that dumping all zone data to console can result in arbitrarily shortened output due to console buffer limitations. Maybe it is better to first collect all data in a `StringBuilder` and then output it. This will not circumvent the buffer limitation but at least the data will be shortened only at the end so  users can better recognize that they use a limited console buffer.
- The `ZoneDumper`-interface could enhanced such that its dump-method writes a result object defined by your project instead of directly writing to a `Writer`. This enables an easier change of output format in the future.
- The term `initial offset` might be misleading for some people. Its position directly above the transition table has first let me think that the last transition before filtered transition table was asked, but it is really the very first transition in records. Only a view inside the existing dumper-implementations had clarified this for me. Maybe it is better to add an extra suffix like "Initially in tz history:" and/or to insert a space and extra caption between this line and the transition table. The caption could indicate the actual year filter (like "Transitions between fromYear and toYear:") to make clear that the transition table is not related to the initial offset. The initial offset should also be an extra result of a separate method in `ZoneDumper`.
