### PR TITLE
Use gcc on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: csharp
 sudo: required
 dist: trusty
+compiler: gcc
 
 install:
   - sudo sh -c 'echo "deb [arch=amd64] https://apt-mo.trafficmanager.net/repos/dotnet-release/ trusty main" > /etc/apt/sources.list.d/dotnetdev.list'


### PR DESCRIPTION
(This is initially to investigate why Travis is failing at the
moment. When there's less urgency in getting 2017c out for Noda
Time, we can look at what's going on more carefully.)